### PR TITLE
Remove bad fittings

### DIFF
--- a/src/Http/Controllers/FittingController.php
+++ b/src/Http/Controllers/FittingController.php
@@ -179,12 +179,16 @@ class FittingController extends Controller implements CalculateConstants
         foreach ($fittings as $fit) {
             $ship = InvType::where('typeName', $fit->shiptype)->first();
 
-            array_push($fitnames, [
-                'id' => $fit->id,
-                'shiptype' => $fit->shiptype,
-                'fitname' => $fit->fitname,
-                'typeID' => $ship->typeID
-            ]);
+            if ($ship && property_exists($ship, 'typeID')) {
+                array_push($fitnames, [
+                    'id' => $fit->id,
+                    'shiptype' => $fit->shiptype,
+                    'fitname' => $fit->fitname,
+                    'typeID' => $ship->typeID
+                ]);
+            } else {
+                $this->deleteFittingById($fit->id);
+            }
         }
 
         return $fitnames;


### PR DESCRIPTION
A fitting can be saved improperly to the DB in a way where future recall (on these lines of code) will fail to resolve the ship type.

**This is entirely user error in the fitting import process...**

However, we can help by not crashing with a HTTP 500 NPE, and also just cleaning up the database when this happens.