### PR TITLE
Add API endpoints for fittings and doctrines

### DIFF
--- a/src/Http/Controllers/ApiFittingController.php
+++ b/src/Http/Controllers/ApiFittingController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Denngarr\Seat\SeatSrp\Http\Controllers;
+namespace Denngarr\Seat\Fitting\Http\Controllers;
 
 use Seat\Api\Http\Controllers\Api\v2\ApiController;
 use Seat\Web\Http\Controllers\FittingController;

--- a/src/Http/Controllers/ApiFittingController.php
+++ b/src/Http/Controllers/ApiFittingController.php
@@ -3,11 +3,11 @@
 namespace Denngarr\Seat\Fitting\Http\Controllers;
 
 use Seat\Api\Http\Controllers\Api\v2\ApiController;
-use Seat\Web\Http\Controllers\FittingController;
+use Denngarr\Seat\Fitting\Http\Controllers\FittingController;
 
 /**
  * Class ApiFittingController.
- * @package Denngarr\Seat\SeatSrp\Http\Controllers
+ * @package Denngarr\Seat\Fitting\Http\Controllers
  */
 class ApiFittingController extends ApiController
 {

--- a/src/Http/Controllers/ApiFittingController.php
+++ b/src/Http/Controllers/ApiFittingController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Denngarr\Seat\SeatSrp\Http\Controllers;
+
+use Seat\Api\Http\Controllers\Api\v2\ApiController;
+use Seat\Web\Http\Controllers\FittingController.php;
+
+/**
+ * Class ApiFittingController.
+ * @package Denngarr\Seat\SeatSrp\Http\Controllers
+ */
+class ApiFittingController extends ApiController
+{
+  
+  public function getFittingList()
+    {
+    return FittingController::getFittingList()
+  }
+  
+  public function getFittingById($id)
+    {
+    return FittingController::getFittingById($id)
+  }
+  
+  public function getDoctrineList()
+    {
+    return FittingController::getDoctrineList()
+  }
+  
+  public function getDoctrineList($id)
+    {
+    return FittingController::getDoctrineById($id)
+  }
+  
+}

--- a/src/Http/Controllers/ApiFittingController.php
+++ b/src/Http/Controllers/ApiFittingController.php
@@ -3,7 +3,7 @@
 namespace Denngarr\Seat\SeatSrp\Http\Controllers;
 
 use Seat\Api\Http\Controllers\Api\v2\ApiController;
-use Seat\Web\Http\Controllers\FittingController.php;
+use Seat\Web\Http\Controllers\FittingController;
 
 /**
  * Class ApiFittingController.

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -7,19 +7,19 @@ Route::group([
 ], function () {
     Route::get('/fitting/list', [
         'as' => 'fitting.api.web.fitting.list',
-        'uses' => 'ApiFittingController.php@getFittingList',
+        'uses' => 'ApiFittingController@getFittingList',
     ]);
     Route::get('/fitting/get/{id}', [
         'as' => 'fitting.api.web.fitting.get',
-        'uses' => 'ApiFittingController.php@getFittingById',
+        'uses' => 'ApiFittingController@getFittingById',
     ]);
     Route::get('/doctrine/list', [
         'as' => 'fitting.api.web.doctrine.list',
-        'uses' => 'ApiFittingController.php@getDoctrineList',
+        'uses' => 'ApiFittingController@getDoctrineList',
     ]);
     Route::get('/doctrine/get/{id}', [
         'as' => 'fitting.api.web.doctrine.get',
-        'uses' => 'ApiFittingController.php@getDoctrineById',
+        'uses' => 'ApiFittingController@getDoctrineById',
     ]);
 });
 

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -2,6 +2,29 @@
 
 Route::group([
     'namespace' => 'Denngarr\Seat\Fitting\Http\Controllers',
+    'middleware' => ['web', 'auth'],
+    'prefix' => 'api/v2/fitting/web',
+], function () {
+    Route::get('/fitting/list', [
+        'as' => 'fitting.api.web.fitting.list',
+        'uses' => 'ApiFittingController.php@getFittingList',
+    ]);
+    Route::get('/fitting/get/{id}', [
+        'as' => 'fitting.api.web.fitting.get',
+        'uses' => 'ApiFittingController.php@getFittingById',
+    ]);
+    Route::get('/doctrine/list', [
+        'as' => 'fitting.api.web.doctrine.list',
+        'uses' => 'ApiFittingController.php@getDoctrineList',
+    ]);
+    Route::get('/doctrine/get/{id}', [
+        'as' => 'fitting.api.web.doctrine.get',
+        'uses' => 'ApiFittingController.php@getDoctrineById',
+    ]);
+});
+
+Route::group([
+    'namespace' => 'Denngarr\Seat\Fitting\Http\Controllers',
     'prefix' => 'fitting'
 ], function () {
     Route::group([


### PR DESCRIPTION
Adds API endpoints to

- List fittings
- Get fitting by id
- List doctrines
- Get doctrine by id

Inspiration and code structure taken from [https://github.com/dysath/seat-srp](https://github.com/dysath/seat-srp)

I don't know PHP or Laravel, so I guessed on how to import and use the FittingController class functions inside ApiFittingController.