### PR TITLE
Add export links

### DIFF
--- a/src/Config/fitting.exportlinks.php
+++ b/src/Config/fitting.exportlinks.php
@@ -1,0 +1,12 @@
+<?php 
+
+return [
+//    'example'=>[
+//        "route"=>"fitting.about",//receives the id as argument
+//        "name"=>"open in seat-alliance-industry"
+//    ],
+//    'example2'=>[
+//        "url"=>"https://example.com",//receives the id as argument
+//        "name"=>"open in seat-inventory"
+//    ]
+];

--- a/src/FittingServiceProvider.php
+++ b/src/FittingServiceProvider.php
@@ -17,6 +17,10 @@ class FittingServiceProvider extends AbstractSeatPlugin
         $this->add_views();
         $this->add_translations();
 
+        $this->publishes([
+            __DIR__.'/Config/fitting.exportlinks.php' => config_path('fitting.exportlinks.php')],["config","seat"]
+        );
+
         $this->addMigrations();
     }
 

--- a/src/Http/Controllers/FittingController.php
+++ b/src/Http/Controllers/FittingController.php
@@ -225,7 +225,16 @@ class FittingController extends Controller implements CalculateConstants
     {
         $fitting = Fitting::find($id);
 
-        return response()->json($this->fittingParser($fitting->eftfitting));
+        $response = $this->fittingParser($fitting->eftfitting);
+
+        $response["exportLinks"] = collect(config("fitting.exportlinks"))->map(function ($link) use ($fitting) {
+            return [
+                "name"=>$link["name"],
+                "url"=>isset($link["url"]) ? $link["url"]."?id=$fitting->id" : route($link["route"],["id"=>$fitting->id])
+            ];
+        })->values();
+
+        return response()->json($response);
     }
 
     public function getFittingView()

--- a/src/resources/views/fitting.blade.php
+++ b/src/resources/views/fitting.blade.php
@@ -68,6 +68,7 @@
         </div>
         <div class="card-body">
             <textarea name="showeft" id="showeft" rows="15" style="width: 100%" onclick="this.focus();this.select()" readonly="readonly"></textarea>
+            <div id="exportLinks" class="mt-2 list-group"></div>
         </div>
         <div class="card-footer">
         Current Jita Price (Buy /Sell)
@@ -215,6 +216,7 @@
     $('#fitting-box').hide();
     $('#skills-box').hide();
     $('#eftexport').hide();
+    $('#exportLinks').hide();
     $('#showeft').val('');
 
     $('#fitlist').DataTable();
@@ -264,6 +266,11 @@
                 .empty();
             $('#showeft').val('');
             $('#fitting-box').show();
+
+            $('#exportLinks').show().empty();
+            for(const link of result.exportLinks){
+                $('#exportLinks').append(`<a href="${link.url}" class="list-group-item list-group-item-action">${link.name}</a>`)
+            }
 
             fillFittingWindow(result);
         });


### PR DESCRIPTION
This PR adds buttons to export fits to plugins. A plugin can register a export URL into `fitting.exportlinks` and a link to export the fit will be added below the eft fit. I plan to use this for a "order with seat-alliance-industry" and "add to seat-inventory" button

![Bildschirmfoto 2023-03-15 um 21 20 39](https://user-images.githubusercontent.com/60423027/225432913-0a1e9f3e-292b-4fb6-b673-3eddf546c92d.png)
